### PR TITLE
fix: update queue queries to use payload JSONB

### DIFF
--- a/src/gateway/blueprints/backfill.py
+++ b/src/gateway/blueprints/backfill.py
@@ -38,11 +38,10 @@ def trigger_backfill():
 
     # Build query to find emails to backfill
     query = """
-        INSERT INTO queue (queue_name, gmail_id, payload, priority, status, created_at)
+        INSERT INTO queue (queue_name, payload, priority, status, created_at)
         SELECT
             %s,
-            er.gmail_id,
-            jsonb_build_object('gmail_id', er.gmail_id, 'backfill', true),
+            jsonb_build_object('email_id', er.id, 'gmail_id', er.gmail_id, 'backfill', true),
             %s,
             'pending',
             NOW()
@@ -60,7 +59,7 @@ def trigger_backfill():
         AND NOT EXISTS (
             SELECT 1 FROM queue q
             WHERE q.queue_name = %s
-            AND q.gmail_id = er.gmail_id
+            AND q.payload->>'gmail_id' = er.gmail_id
             AND q.status IN ('pending', 'processing')
         )
     """

--- a/src/gateway/blueprints/queue.py
+++ b/src/gateway/blueprints/queue.py
@@ -47,12 +47,12 @@ def list_failed():
         SELECT
             id,
             queue_name,
-            gmail_id,
+            payload->>'gmail_id' as gmail_id,
             payload,
-            error,
+            last_error as error,
             attempts,
             created_at,
-            updated_at
+            claimed_at as updated_at
         FROM queue
         WHERE status = 'failed'
     """
@@ -82,7 +82,7 @@ def retry_failed(job_id: int) -> Response | tuple[Response, int]:
     """Retry a failed job by resetting its status to pending."""
     # First verify it exists and is failed
     check_query = """
-        SELECT id, queue_name, gmail_id, status
+        SELECT id, queue_name, payload->>'gmail_id' as gmail_id, status
         FROM queue
         WHERE id = %s
     """


### PR DESCRIPTION
## Summary
- Queue table was partitioned and gmail_id moved into payload JSONB
- Updated all INSERT and SELECT queries to use correct schema
- Fixes `column "gmail_id" of relation "queue" does not exist` errors

## Changes
- `triage.py`: Fixed INSERT queries and duplicate check
- `backfill.py`: Fixed INSERT query and duplicate check  
- `queue.py`: Fixed SELECT queries for failed jobs listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)