### PR TITLE
Send config_reload signal on config update

### DIFF
--- a/src/gateway/blueprints/config.py
+++ b/src/gateway/blueprints/config.py
@@ -327,7 +327,7 @@ def rollback_to_version(version: int) -> Response | tuple[Response, int]:
                     500,
                 )
 
-            # Mark as rollback in database
+            # Mark as rollback in database and send reload signal
             with conn.cursor() as cursor:
                 cursor.execute(
                     """
@@ -336,6 +336,12 @@ def rollback_to_version(version: int) -> Response | tuple[Response, int]:
                     WHERE version = %s
                     """,
                     (version, new_version),
+                )
+                cursor.execute(
+                    "INSERT INTO worker_signals"
+                    " (signal_type, target_worker, payload)"
+                    " VALUES ('config_reload', 'all', %s)",
+                    (Json({"version": new_version}),),
                 )
             conn.commit()
 

--- a/src/gateway/blueprints/config.py
+++ b/src/gateway/blueprints/config.py
@@ -10,6 +10,7 @@ from cortex_utils.triage_config import (
     validate_rules,
 )
 from flask import Blueprint, Response, jsonify, request
+from psycopg2.extras import Json
 from yaml import YAMLError
 
 from gateway.services.postgres import ConnectionContext, execute_query
@@ -163,6 +164,11 @@ def update_config() -> Response | tuple[Response, int]:
         # If validation passes, import to database
         with ConnectionContext() as conn:
             version = import_yaml_to_db(conn, yaml_content, created_by, notes)
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    "INSERT INTO worker_signals (signal_type, target_worker, payload) VALUES ('config_reload', 'all', %s)",
+                    (Json({"version": version}),),
+                )
             conn.commit()
 
         return (

--- a/src/gateway/blueprints/config.py
+++ b/src/gateway/blueprints/config.py
@@ -166,7 +166,9 @@ def update_config() -> Response | tuple[Response, int]:
             version = import_yaml_to_db(conn, yaml_content, created_by, notes)
             with conn.cursor() as cursor:
                 cursor.execute(
-                    "INSERT INTO worker_signals (signal_type, target_worker, payload) VALUES ('config_reload', 'all', %s)",
+                    "INSERT INTO worker_signals"
+                    " (signal_type, target_worker, payload)"
+                    " VALUES ('config_reload', 'all', %s)",
                     (Json({"version": version}),),
                 )
             conn.commit()

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ dev = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
     { name = "click", specifier = ">=8.0.0" },
-    { name = "cortex-utils", git = "https://github.com/devonjones/cortex-utils.git?rev=main" },
+    { name = "cortex-utils", git = "https://github.com/devonjones/cortex-utils.git?rev=318c38c" },
     { name = "flask", specifier = ">=3.0.0" },
     { name = "google-auth", specifier = ">=2.0.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.0.0" },
@@ -226,7 +226,7 @@ provides-extras = ["dev"]
 [[package]]
 name = "cortex-utils"
 version = "0.1.0"
-source = { git = "https://github.com/devonjones/cortex-utils.git?rev=main#8bad5b062bf2c5e815855c4d47bd76687a9577ac" }
+source = { git = "https://github.com/devonjones/cortex-utils.git?rev=318c38c#318c38c482cf5c45d480f36cd1419c2989c467ec" }
 dependencies = [
     { name = "click" },
     { name = "docker" },


### PR DESCRIPTION
## Summary
- Gateway now inserts a `config_reload` signal into `worker_signals` table when a new config version is created via `PUT /config`
- Triage worker picks this up within 30 seconds and hot-reloads without restart
- Previously required manual `SIGHUP` or container restart after config changes

## Test plan
- [x] Upload new config via PUT /config
- [x] Triage worker auto-reloads within 30 seconds
- [x] Logs show "Config reloaded successfully via signal"

🤖 Generated with [Claude Code](https://claude.com/claude-code)