### PR TITLE
chore: bump cortex-utils to fe447ce (parity with triage)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "httpx>=0.27.0",
     "click>=8.0.0",
     "structlog>=24.0.0",
-    "cortex-utils @ git+https://github.com/devonjones/cortex-utils.git@9a30918",
+    "cortex-utils @ git+https://github.com/devonjones/cortex-utils.git@fe447ce",
     "google-auth>=2.0.0",
     "google-auth-oauthlib>=1.0.0",
 ]
@@ -74,3 +74,6 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v"
+
+[tool.ruff.lint.isort]
+known-first-party = ["gateway"]

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ dev = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
     { name = "click", specifier = ">=8.0.0" },
-    { name = "cortex-utils", git = "https://github.com/devonjones/cortex-utils.git?rev=9a30918" },
+    { name = "cortex-utils", git = "https://github.com/devonjones/cortex-utils.git?rev=fe447ce" },
     { name = "flask", specifier = ">=3.0.0" },
     { name = "google-auth", specifier = ">=2.0.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.0.0" },
@@ -226,7 +226,7 @@ provides-extras = ["dev"]
 [[package]]
 name = "cortex-utils"
 version = "0.1.0"
-source = { git = "https://github.com/devonjones/cortex-utils.git?rev=9a30918#9a30918ee3a6f1903dd7342361b9342c6c3dfb92" }
+source = { git = "https://github.com/devonjones/cortex-utils.git?rev=fe447ce#fe447ce13c8beac9040097ee37d02628ce218ff0" }
 dependencies = [
     { name = "click" },
     { name = "docker" },


### PR DESCRIPTION
## Summary
Bumps gateway's cortex-utils pin from `9a30918` → `fe447ce` so gateway and triage run the **same** cortex-utils revision. Triage moved to `fe447ce` on main; this closes the 2-commit drift (120s LLM timeout + #18 queue backoff-retry).

Also adds `[tool.ruff.lint.isort] known-first-party = ["gateway"]` to reconcile the pinned pre-commit ruff (v0.1.6) with the project/CI ruff (0.14.7): the two disagreed on import grouping for `gateway` imports in `tests/test_queue.py` (old ruff treated it as third-party). CI only lints `src/` so this was invisible to CI but blocked local commits.

## Test plan
- [x] `uv lock` regenerated cleanly (no lingering 9a30918 refs)
- [x] ruff / black / mypy / pytest (16) all green against fe447ce
- [x] `pre-commit run --all-files` green (both ruff versions agree now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)