### PR TITLE
fix(config): /config/validate crashes on ChainConfig rule count

### DIFF
--- a/src/gateway/blueprints/config.py
+++ b/src/gateway/blueprints/config.py
@@ -239,9 +239,10 @@ def validate_config() -> Response | tuple[Response, int]:
                 400,
             )
 
-        # Count components
+        # Count components. chains are ChainConfig objects (rules live on
+        # .rules); iterating a ChainConfig directly raises "no len()".
         chain_count = len(config.chains)
-        rule_count = sum(len(rules) for rules in config.chains.values())
+        rule_count = sum(len(chain.rules) for chain in config.chains.values())
         priority_mappings = len(config.priority_email_mappings)
         fallback_mappings = len(config.fallback_email_mappings)
 
@@ -410,7 +411,7 @@ def diff_versions(v1: int, v2: int) -> Response | tuple[Response, int]:
                 "added": added_lines[:100],  # Limit to first 100 for API response
                 "removed": removed_lines[:100],
                 "note": (
-                    "Use GET /config/versions/{v} to download full YAML " "for detailed comparison"
+                    "Use GET /config/versions/{v} to download full YAML for detailed comparison"
                 ),
             }
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,55 @@
+"""Tests for config API endpoints."""
+
+import pytest
+from flask import Flask
+
+from gateway.blueprints.config import config_bp
+
+# Minimal valid config with a chain that has rules. Exercises the real
+# normalize_chains -> ChainConfig path so the rule-count stat is computed
+# against ChainConfig objects (regression: cortex-fzkj).
+VALID_YAML = """
+default_label: Uncategorized
+label_prefix: Cortex
+chains:
+  main:
+    auto_run: true
+    rules:
+      - match:
+          from_contains: example.com
+        action:
+          label: Test
+      - match:
+          from_contains: other.com
+        action:
+          label: Other
+"""
+
+
+@pytest.fixture
+def client():
+    app = Flask("test")
+    app.register_blueprint(config_bp, url_prefix="/config")
+    return app.test_client()
+
+
+def test_validate_returns_stats_for_chainconfig(client):
+    """/config/validate must count rules on ChainConfig.rules, not len(chain).
+
+    Regression for cortex-fzkj: chains are ChainConfig objects, and
+    sum(len(chain) ...) raised 'object of type ChainConfig has no len()',
+    500-ing every validation.
+    """
+    response = client.post("/config/validate", data=VALID_YAML, content_type="text/plain")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["valid"] is True
+    assert data["stats"]["chains"] == 1
+    assert data["stats"]["rules"] == 2
+
+
+def test_validate_rejects_invalid_yaml(client):
+    """Malformed YAML is a 400, not a 500."""
+    response = client.post("/config/validate", data="{not: valid: yaml:", content_type="text/plain")
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
`POST /config/validate` always returned **500** (`object of type 'ChainConfig' has no len()`). It computed `sum(len(rules) for rules in config.chains.values())`, but `chains` values are `ChainConfig` objects — rules live on `.rules`.

The real validation (`validate_rules`) runs and passes *before* this line, and `PUT/POST /config` has no such counter, so config **uploads were never affected** — only the read-only validate endpoint (and its stats) was broken.

**Fix:** `sum(len(chain.rules) for chain in config.chains.values())`.

## Test plan
- New `tests/test_config.py`: posts a real 2-rule config and asserts `200` + `stats.rules == 2` (would 500 before the fix), plus a malformed-YAML → 400 case.
- Full suite green (18 passed); `ruff`/`mypy`/`black`/`isort` clean.

Found while removing the catch-all `Uncategorized` rule (cortex-57gz).

cortex-fzkj

🤖 Generated with [Claude Code](https://claude.com/claude-code)